### PR TITLE
Bug fixes for importing ReCiPe 2016 impact categories into bw projects

### DIFF
--- a/bw_recipe_2016/categories/land.py
+++ b/bw_recipe_2016/categories/land.py
@@ -26,6 +26,7 @@ class LandTransformation(ReCiPe2016):
         self.strategies = [
             partial(generic_reformat, config=self.config),
             set_unit,
+            reset_categories,
             partial(
                 complete_method_name, name="Land transformation", config=self.config
             ),

--- a/bw_recipe_2016/strategies/string_manipulation.py
+++ b/bw_recipe_2016/strategies/string_manipulation.py
@@ -27,7 +27,7 @@ def split_synonyms(data):
     E.g. ``dinitrogen oxide (nitrous oxide)`` to ``["dinitrogen oxide", "nitrous oxide"]``,"""
     for ds in data:
         for cf in ds["exchanges"]:
-            if "synonyms" in cf:
+            if cf.get("synonyms"):
                 match = multiple.match(cf["synonyms"])
                 if match:
                     cf["synonyms"] = [x.strip() for x in match.groups()]


### PR DESCRIPTION
land.py: Categories where missing for the land transformation impact category causing an error down the road when trying to match the biosphere flows of the characterisation factors with the ones in the biosphere database in match_multiple. The strategy reset_categories was used to avoid this error analogous to the land occupation category.

string_manipulation.py: An error occured in some cases where the key "synonyms" existed but its value was None. Workaround uses dict.get() method which returns the value if the key exists or None if the key does not exist causing the following lines to be skipped as well if the value is None.